### PR TITLE
Fixed stylelint fails due to missing dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Standard stylelint config for Netzstrategen projects.
 Install the configuration and all peer dependencies:
 
 ```bash
-npm install --save-dev @netzstrategen/stylelint-config stylelint-scss stylelint-selector-bem-pattern stylelint
+npm install --save-dev @netzstrategen/stylelint-config stylelint stylelint-scss stylelint-selector-bem-pattern
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Standard stylelint config for Netzstrategen projects.
 Install the configuration and all peer dependencies:
 
 ```bash
-npm install --save-dev @netzstrategen/stylelint-config stylelint
+npm install --save-dev @netzstrategen/stylelint-config stylelint-scss stylelint-selector-bem-pattern stylelint
 ```
 
 ## Usage


### PR DESCRIPTION
v2 removed stylelint-scss and stylelint-selector-bem-pattern from the dependencies, which causes them to not be installed anymore in the project that is using stylelint-config:
https://github.com/netzstrategen/stylelint-config/commit/434fb46eb0569bc58f5a84ce3b905d469436b142#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-L23

That is, because devDependencies of dependencies are not inherited / installed.

Only stylelint-order is not necessary anymore because it is required upstream already:
https://github.com/stormwarning/zazen-stylelint-config/blob/main/package.json#L39